### PR TITLE
Fix serde scalar leakage

### DIFF
--- a/src/presign.rs
+++ b/src/presign.rs
@@ -192,11 +192,20 @@ pub fn presign<C: CSCurve>(
     })?;
 
     let all_bt_ids = ParticipantList::new(bt_participants).ok_or_else(|| {
-        InitializationError::BadParameters("bt_participants list cannot contain duplicates".to_string())
+        InitializationError::BadParameters(
+            "bt_participants list cannot contain duplicates".to_string(),
+        )
     })?;
 
     let ctx = Context::new();
-    let fut = do_presign(ctx.shared_channel(), participants, me, all_bt_ids, bt_id, args);
+    let fut = do_presign(
+        ctx.shared_channel(),
+        participants,
+        me,
+        all_bt_ids,
+        bt_id,
+        args,
+    );
     Ok(make_protocol(ctx, fut))
 }
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -5,8 +5,7 @@
 //! to deliver messages to and from that protocol, and eventually it will produce
 //! a result, without you having to worry about how many rounds it has, or how
 //! to serialize the emssages it produces.
-use core::fmt;
-use std::{collections::HashMap, error};
+use std::{collections::HashMap, error, fmt};
 
 use ::serde::{Deserialize, Serialize};
 
@@ -49,7 +48,7 @@ pub enum InitializationError {
 }
 
 impl fmt::Display for InitializationError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             InitializationError::BadParameters(s) => write!(f, "bad parameters: {}", s),
         }
@@ -195,7 +194,7 @@ pub fn run_protocol<T>(
 ///
 /// This is more useful for testing two party protocols with assymetric results,
 /// since the return types for the two protocols can be different.
-pub(crate) fn run_two_party_protocol<T0: std::fmt::Debug, T1: std::fmt::Debug>(
+pub(crate) fn run_two_party_protocol<T0: fmt::Debug, T1: fmt::Debug>(
     p0: Participant,
     p1: Participant,
     prot0: &mut dyn Protocol<Output = T0>,

--- a/src/triples/batch_random_ot.rs
+++ b/src/triples/batch_random_ot.rs
@@ -118,8 +118,8 @@ pub async fn batch_random_ot_sender_many<C: CSCurve, const N: usize>(
                 let big_y_affine = &big_y_affine_v_arc.as_slice()[j];
                 let big_z = &big_z_v_arc.as_slice()[j];
                 let y_big_x_i = big_x_i_affine_v[j].to_projective() * *y;
-                let big_k0 = hash(i, &big_x_i_affine_v[j], &big_y_affine, &y_big_x_i);
-                let big_k1 = hash(i, &big_x_i_affine_v[j], &big_y_affine, &(y_big_x_i - big_z));
+                let big_k0 = hash(i, &big_x_i_affine_v[j], big_y_affine, &y_big_x_i);
+                let big_k1 = hash(i, &big_x_i_affine_v[j], big_y_affine, &(y_big_x_i - big_z));
                 ret.push((big_k0, big_k1));
             }
 
@@ -202,7 +202,7 @@ pub async fn batch_random_ot_receiver_many<C: CSCurve, const N: usize>(
     let mut big_y_v = vec![];
     let mut deltav = vec![];
     for i in 0..N {
-        let big_y_affine = big_y_affine_v[i].clone();
+        let big_y_affine = big_y_affine_v[i];
         let big_y = big_y_affine.to_projective();
         if bool::from(big_y.is_identity()) {
             return Err(ProtocolError::AssertionFailed(
@@ -229,7 +229,7 @@ pub async fn batch_random_ot_receiver_many<C: CSCurve, const N: usize>(
         }
     }
     // wrap in arc
-    let choices: Vec<_> = choices.into_iter().map(|c| Arc::new(c)).collect();
+    let choices: Vec<_> = choices.into_iter().map(Arc::new).collect();
 
     let mut tasks = Vec::new();
     for i in 0..choices.len() {
@@ -290,7 +290,7 @@ pub async fn batch_random_ot_receiver_many<C: CSCurve, const N: usize>(
     for j in 0..N {
         let delta = deltav[j];
         let out = &outs[j];
-        let big_k: BitMatrix = out.into_iter().cloned().collect();
+        let big_k: BitMatrix = out.iter().cloned().collect();
         let h = SquareBitMatrix::try_from(big_k);
         ret.push((delta, h.unwrap()))
     }

--- a/src/triples/generation.rs
+++ b/src/triples/generation.rs
@@ -712,7 +712,7 @@ async fn do_generation_many<C: CSCurve, const N: usize>(
             }
             if !all_commitments[from].check(
                 &(&their_big_e, &their_big_f, &their_big_l),
-                &their_randomizer,
+                their_randomizer,
             ) {
                 return Err(ProtocolError::AssertionFailed(format!(
                     "commitment from {from:?} did not match revealed F"
@@ -724,7 +724,7 @@ async fn do_generation_many<C: CSCurve, const N: usize>(
             if !dlog::verify(
                 &mut transcript.forked(b"dlog0", &from.bytes()),
                 statement0,
-                &their_phi_proof0,
+                their_phi_proof0,
             ) {
                 return Err(ProtocolError::AssertionFailed(format!(
                     "dlog proof from {from:?} failed to verify"
@@ -737,7 +737,7 @@ async fn do_generation_many<C: CSCurve, const N: usize>(
             if !dlog::verify(
                 &mut transcript.forked(b"dlog1", &from.bytes()),
                 statement1,
-                &their_phi_proof1,
+                their_phi_proof1,
             ) {
                 return Err(ProtocolError::AssertionFailed(format!(
                     "dlog proof from {from:?} failed to verify"

--- a/src/triples/multiplication.rs
+++ b/src/triples/multiplication.rs
@@ -79,7 +79,7 @@ pub async fn multiplication_sender_many<'a, C: CSCurve, const N: usize>(
                 batch_size: 2 * batch_size,
             },
             *delta,
-            &k,
+            k,
         )
         .await?;
         let res1 = res0.split_off(batch_size);
@@ -156,8 +156,8 @@ pub async fn multiplication_receiver_many<'a, C: CSCurve, const N: usize>(
                 sid: sid[i].as_ref(),
                 batch_size: 2 * batch_size,
             },
-            &k0,
-            &k1,
+            k0,
+            k1,
         )
         .await?;
         let res1 = res0.split_off(batch_size);


### PR DESCRIPTION
From Thomas Pornin


> While trying to work out what was actually expensive in the TripleGen protocol, by instrumenting the code and measuring the message sizes, there is an actual RustCrypto bug or misfeature (apparently already known to them), which has two important consequences: it makes messages about 50% larger than necessary, and it implies some side channel leakages. The leaks, by themselves, imply that you'll want to fix that, but that will also plausibly improve your performance.

This address this issue in that the leak was when the encoded length depends on the values of the bytes. No variation in length = no leak. In this case there is no variation any more.

We'll need to apply a similar fix to all other messages in the protocol as well but this is a first pass.